### PR TITLE
fear: split create (broken example

### DIFF
--- a/src/pipeline/pipeline.ts
+++ b/src/pipeline/pipeline.ts
@@ -62,6 +62,7 @@ type Response = {
 		}[];
 		// mutations
 		insertions?: ConceptMap[];
+		creations?: ConceptMap[];
 	};
 	cache?: {
 		entities: Map<EntityName, Map<EntityID, Entity>>;

--- a/src/pipeline/preprocess/mutation/parseBQLMutation.ts
+++ b/src/pipeline/preprocess/mutation/parseBQLMutation.ts
@@ -406,8 +406,8 @@ export const parseBQLMutation: PipelineOperation = async (req) => {
 	}
 
 	const [parsedThings, parsedEdges] = listNodes(filledBqlRequest);
-	//console.log('parsedThings', parsedThings);
-	//console.log('parsedEdges', parsedEdges);
+	console.log('parsedThings', parsedThings);
+	console.log('parsedEdges', parsedEdges);
 
 	/// some cases where we extract things, they must be ignored.
 	/// One of this cases is the situation where we have a thing that is linked somwhere and created, or updated.

--- a/src/pipeline/transaction/runTQLQuery.ts
+++ b/src/pipeline/transaction/runTQLQuery.ts
@@ -12,7 +12,7 @@ export const newRunTQLQuery: PipelineOperation = async (req, res) => {
 	if (!tqlRequest) {
 		throw new Error('TQL request not built');
 	}
-	//console.log('tqlRequest!', tqlRequest);
+	//console.log('tqlRequest', tqlRequest);
 
 	const isBatched = Array.isArray(tqlRequest);
 	if (isBatched) {

--- a/src/types/requests/databases/typeql.ts
+++ b/src/types/requests/databases/typeql.ts
@@ -6,6 +6,7 @@ export type TQLRequest = {
 	// mutations
 	insertionMatches?: string;
 	deletionMatches?: string;
+	creations?: string;
 	insertions?: string;
 	deletions?: string;
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 51afe00e5194a054aa3c5427c55fdd7779200c6e  | 
|--------|--------|

### Summary:
This PR introduces handling for a new 'creations' mutation type in the TQL processing pipeline, affecting type definitions and several processing stages.

**Key points**:
- Added `creations` field to `TQLRequest` type in `src/types/requests/databases/typeql.ts`.
- Updated `buildTQLMutation` in `src/pipeline/preprocess/mutation/buildTQLMutation.ts` to handle `creations`.
- Modified `runTQLMutation` in `src/pipeline/transaction/runTQLMutation.ts` to execute creation operations.
- Adjusted `pipeline.ts` to include `creations` in the `Response` type.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->