### PR TITLE
draft: surrealdb mutations

### DIFF
--- a/src/stateMachine/mutation/SUQL/build.ts
+++ b/src/stateMachine/mutation/SUQL/build.ts
@@ -1,0 +1,383 @@
+import { isArray, listify, mapEntries, shake } from 'radash';
+
+import { getCurrentSchema, isBQLBlock } from '../../../helpers';
+import type { EnrichedBormSchema, EnrichedBQLMutationBlock } from '../../../types';
+import { EdgeType } from '../../../types/symbols';
+
+export const buildSUQLMutation = async (things: any, edges: any, schema: EnrichedBormSchema) => {
+	// todo: Split attributes and edges
+	const nodeToTypeQL = (
+		node: EnrichedBQLMutationBlock,
+	): {
+		preDeletionBatch?: any[];
+		deletionMatch?: string;
+		insertionMatch?: string;
+		deletion?: string;
+		insertion?: string;
+		op: string;
+	} => {
+		const op = node.$op as string;
+		const bzId = `$${node.$bzId}`;
+		const currentSchema = getCurrentSchema(schema, node);
+		const { idFields, defaultDBConnector } = currentSchema;
+
+		const thingDbPath = defaultDBConnector?.path || node.$thing;
+
+		const idValue = node.$id;
+
+		// todo: composite ids
+		const idField = idFields?.[0];
+
+		//@ts-expect-error - TODO
+		const attributes = listify(node, (k, v) => {
+			// @ts-expect-error - TODO description
+			if (k.startsWith('$') || k === idField || v === undefined || v === null) {
+				return '';
+			}
+			// if (k.startsWith('$') || !v) return '';
+			const currentDataField = currentSchema.dataFields?.find((x) => x.path === k);
+			// console.log('currentDataField', currentDataField);
+			const fieldDbPath = currentDataField?.path;
+
+			if (!fieldDbPath) {
+				// throw new Error('noFieldDbPath');
+				return '';
+			}
+			const dbField = currentDataField.dbPath;
+
+			if (['TEXT', 'ID', 'EMAIL'].includes(currentDataField.contentType)) {
+				return `has ${dbField} '${v}'`;
+			}
+			if (['NUMBER', 'BOOLEAN'].includes(currentDataField.contentType)) {
+				return `has ${dbField} ${v}`;
+			}
+			if (currentDataField.contentType === 'DATE') {
+				if (Number.isNaN(v.valueOf())) {
+					throw new Error('Invalid format, Nan Date');
+				}
+				if (v instanceof Date) {
+					return `has ${dbField} ${v.toISOString().replace('Z', '')}`;
+				}
+				return `has ${dbField} ${new Date(v).toISOString().replace('Z', '')}`;
+			}
+			throw new Error(`Unsupported contentType ${currentDataField.contentType}`);
+		}).filter((x) => x);
+
+		const attributesVar = `${bzId}-atts`;
+
+		//@ts-expect-error - TODO
+		const matchAttributes = listify(node, (k) => {
+			// @ts-expect-error - TODO description
+			if (k.startsWith('$') || k === idField) {
+				return '';
+			}
+			// if (k.startsWith('$') || !v) return '';
+			const currentDataField = currentSchema.dataFields?.find((x) => x.path === k);
+			// console.log('currentDataField', currentDataField);
+			const fieldDbPath = currentDataField?.path;
+
+			if (!fieldDbPath) {
+				// throw new Error('noFieldDbPath');
+				return '';
+			}
+			const dbField = currentDataField.dbPath;
+
+			return `{${attributesVar} isa ${dbField};}`;
+		}).filter((x) => x);
+
+		const idValueTQL = isArray(idValue) ? `like '${idValue.join('|')}'` : `'${idValue}'`;
+		const idAttributes = idValue // it must have id values, and they must be realDBIds
+			? // if it is a relation, add only the id fields in the lines where we add the roles also so it does not get defined twice
+				[`has ${idField} ${idValueTQL}`]
+			: [];
+
+		const allAttributes = [...idAttributes, ...attributes].filter((x) => x).join(',');
+
+		const getDeletionMatchInNodes = () => {
+			// if (node.$tempId) return ''; /// commented because we need tempIds to work when replacing a unlink/link all operation
+			// todo: ensure parents belong to grandparents. [https://github.com/Blitzapps/blitz/issues/9]
+			if (op === 'delete' || op === 'unlink' || op === 'match') {
+				return `${bzId} isa ${[thingDbPath, ...idAttributes].filter((x) => x).join(',')};`;
+			}
+			if (op === 'update') {
+				if (!matchAttributes.length) {
+					throw new Error('update without attributes');
+				}
+				return `${bzId} isa ${[thingDbPath, ...idAttributes].filter((x) => x).join(',')}, has ${attributesVar};
+        ${matchAttributes.join(' or ')};`;
+			}
+			return '';
+		};
+
+		const getInsertionMatchInNodes = () => {
+			// todo: ensure parents belong to grandparents. [https://github.com/Blitzapps/blitz/issues/9]
+			// if (node.$tempId) return ''; /// same as getDeletionMatch
+			if (op === 'update' || op === 'link' || op === 'match') {
+				return `${bzId} isa ${[thingDbPath, ...idAttributes].filter((x) => x).join(',')};`;
+			}
+			return '';
+		};
+
+		if (isBQLBlock(node)) {
+			return {
+				op,
+				deletionMatch: getDeletionMatchInNodes(),
+				insertionMatch: getInsertionMatchInNodes(),
+				insertion:
+					op === 'create'
+						? `${bzId} isa ${[thingDbPath, allAttributes].filter((x) => x).join(',')};`
+						: op === 'update' && attributes.length
+							? `${bzId} ${attributes.join(',')};`
+							: '',
+				deletion:
+					op === 'delete'
+						? `${bzId} isa ${thingDbPath};`
+						: op === 'update' && matchAttributes.length
+							? `${bzId} has ${attributesVar};`
+							: '',
+			};
+		}
+
+		throw new Error('in attributes');
+	};
+
+	const edgeToTypeQL = (
+		node: EnrichedBQLMutationBlock,
+	): {
+		preDeletionBatch?: any[];
+		deletionMatch?: string;
+		insertionMatch?: string;
+		deletion?: string;
+		insertion?: string;
+		op: string;
+	} => {
+		const op = node.$op as string;
+		const currentSchema = getCurrentSchema(schema, node);
+		const bzId = `$${node.$bzId}`;
+		const idValue = node.$id;
+
+		const relationDbPath = currentSchema.defaultDBConnector?.path || node.$thing;
+
+		const roleFields = 'roles' in currentSchema ? listify(currentSchema.roles, (k) => k) : [];
+
+		const roleDbPaths =
+			'roles' in currentSchema
+				? mapEntries(currentSchema.roles, (k, v) => [k, v.dbConnector?.path || k])
+				: ({} as { [k: string]: string });
+
+		// roles can be specified in three ways, either they are a roleField in the node, they are the children of something, or they have a default/computed link
+		// 1) roleFields
+
+		//@ts-expect-error - TODO
+		const fromRoleFields = listify(node, (k: string, v) => {
+			if (!roleFields.includes(k)) {
+				return null;
+			}
+			if (!('roles' in currentSchema)) {
+				throw new Error('This should have roles! ');
+			}
+			const roleDbPath = roleDbPaths[k];
+			if (Array.isArray(v)) {
+				return v.map((x) => ({ path: roleDbPath, id: x }));
+			}
+			return { path: roleDbPath, id: v };
+		})
+			.filter((x) => x)
+			.flat();
+
+		/// if one of the roles's id is undefined it means it applies to every object of that thingType so we need to create an id for it
+		const fromRoleFieldsTql = fromRoleFields.map((x) => {
+			//@ts-expect-error - TODO
+			if (!x?.path) {
+				throw new Error('Object without path');
+			}
+			//@ts-expect-error - TODO
+			return `${x.path}: $${x.id}`;
+		});
+
+		const roles = fromRoleFields.length > 0 ? `( ${fromRoleFieldsTql.join(' , ')} )` : '';
+
+		// console.log('roles', roles);
+
+		const edgeType = node[EdgeType];
+		if (!edgeType) {
+			throw new Error('[internal error] Symbol edgeType not defined');
+		}
+
+		const relationTql = !roles
+			? ''
+			: `${bzId} ${roles} ${
+					edgeType === 'linkField' || op === 'delete' || op === 'unlink' ? `isa ${relationDbPath}` : ''
+				}`;
+
+		const relationTqlWithoutRoles = `${bzId}  ${
+			edgeType === 'linkField' || op === 'delete' ? `isa ${relationDbPath}` : ''
+		}`;
+
+		const getInsertionsInEdges = () => {
+			if (!relationTql) {
+				return '';
+			}
+			if (op === 'link') {
+				return `${relationTql};`;
+			}
+			if (op === 'create') {
+				return `${relationTql}, has id '${idValue}';`;
+			}
+			return '';
+		};
+
+		const getInsertionMatchInEdges = () => {
+			if (!relationTql) {
+				return '';
+			}
+			// if (op === 'link') return `${relationTql};`;
+			// if (op === 'create') return `${relationTqlWithoutRoles};`;
+			if (op === 'match') {
+				return `${relationTql};`;
+			}
+			return '';
+		};
+
+		const getDeletionMatchInEdges = () => {
+			if (!relationTql) {
+				return '';
+			}
+			/// edge delete: we are removing an automatic relation
+			if (op === 'delete') {
+				return `${relationTql};`;
+			}
+			/// edge unlink means: We are editing a real relation's roles
+			if (op === 'unlink') {
+				/*  return `${bzId} ($roles-${node.$bzId}: $players-${node.$bzId}) isa ${relationDbPath}; ${fromRoleFields
+          .map((role) => `{$roles-${node.$bzId} type ${relationDbPath}:${role?.path};}`)
+          .join(` or `)};`; */
+				/// unlinking more than one role is not supported yet
+				/// this got commented as the match brings what is needed but will probably need a refacto
+				/// this is coded as generating a match block in [parseBQLmutation.ts], toEdges(edgeType1)
+				// return `${bzId} ${roles} isa ${relationDbPath};`;
+				//return `${relationTql};`; //!this fixes rep-del1 but breaks other tests, ideally should be added
+			}
+			if (op === 'match') {
+				return `${relationTql};`;
+			}
+			return '';
+		};
+
+		const getDeletionsInEdges = () => {
+			if (!relationTql) {
+				return '';
+			}
+			// todo: same as insertions, better manage the ids here
+			if (op === 'delete') {
+				return `${relationTqlWithoutRoles};`;
+			}
+			if (op === 'unlink') {
+				return `${bzId} ${roles};`;
+			}
+			// if (op === 'unlink') return `${bzId} ($roles-${node.$bzId}: $players-${node.$bzId});`;
+			return '';
+		};
+
+		/* const getPreDeletionBatch = () => {
+      if (op === 'unlink') {
+        return fromRoleFields
+          .filter((y) => y)
+          .map((x) => {
+            return {
+              match: `${bzId} (${x?.path}: $${x?.id}) isa ${relationDbPath};`,
+              deletion: `${bzId} (${x?.path}: $${x?.id}) ${
+                node[Symbol.for('edgeType') as any] === 'linkField' ? `isa ${relationDbPath}` : ''
+              }`,
+            };
+          });
+      }
+      return [];
+    }; */
+
+		return {
+			// preDeletionBatch: getPreDeletionBatch(),
+			deletionMatch: getDeletionMatchInEdges(),
+			insertionMatch: getInsertionMatchInEdges(),
+			deletion: getDeletionsInEdges(),
+			insertion: getInsertionsInEdges(),
+			op: '',
+		};
+	};
+
+	const toTypeQL = (
+		nodes: EnrichedBQLMutationBlock[] | EnrichedBQLMutationBlock,
+		mode?: 'nodes' | 'edges',
+	):
+		| {
+				preDeletionBatch?: any[];
+				insertionMatch?: string;
+				deletionMatch?: string;
+				insertion?: string;
+				deletion?: string;
+		  }[]
+		| {
+				preDeletionBatch?: any[];
+				insertionMatch?: string;
+				deletionMatch?: string;
+				insertion?: string;
+				deletion?: string;
+		  } => {
+		const typeQL = mode === 'edges' ? edgeToTypeQL : nodeToTypeQL;
+
+		if (Array.isArray(nodes)) {
+			return nodes
+				.map((x) => {
+					const { preDeletionBatch, insertionMatch, deletionMatch, insertion, deletion } = typeQL(x);
+					return shake({ preDeletionBatch, insertionMatch, deletionMatch, insertion, deletion }, (z) => !z); /// ! WARNING: falsy values are removed (0, "", etc)
+				})
+				.filter((y) => y);
+		}
+		const { preDeletionBatch, insertionMatch, deletionMatch, insertion, deletion } = typeQL(nodes);
+
+		return shake({ preDeletionBatch, insertionMatch, deletionMatch, insertion, deletion }, (z) => !z); /// ! WARNING: falsy values are removed (0, "", etc)
+	};
+
+	const nodeOperations = toTypeQL(things);
+	const arrayNodeOperations = Array.isArray(nodeOperations) ? nodeOperations : [nodeOperations];
+	const edgeOperations = toTypeQL(edges, 'edges');
+	const arrayEdgeOperations = Array.isArray(edgeOperations) ? edgeOperations : [edgeOperations];
+	//console.log('nodeOperations', nodeOperations);
+	//console.log('edgeOperations', edgeOperations);
+
+	const allOperations = [...arrayNodeOperations, ...arrayEdgeOperations];
+	//console.log('allOperations', allOperations);
+
+	// todo: split BQL mutation in N DBstreams per DB
+	// todo: then pack them per DB,
+	// const dbHandleList = config.dbConnectors.map((x) => x.id);
+
+	// const creations = [];
+
+	const tqlMutation = shake(
+		{
+			// preDeletionBatch: allOperations.flatMap((x) => x.preDeletionBatch).filter((y) => y !== undefined),
+			insertionMatches: allOperations
+				.map((x) => x.insertionMatch)
+				.join(' ')
+				.trim(),
+			deletionMatches: allOperations
+				.map((x) => x.deletionMatch)
+				.join(' ')
+				.trim(),
+			insertions: allOperations
+				.map((x) => x.insertion)
+				.join(' ')
+				.trim(),
+			deletions: allOperations
+				.map((x) => x.deletion)
+				.join(' ')
+				.trim(),
+			// ...(typeQLRelations?.length && { relations: typeQLRelations }),
+		},
+		(x) => !x,
+	);
+
+	//console.log('tqlMutation', tqlMutation);
+	return tqlMutation;
+};

--- a/src/stateMachine/mutation/SUQL/parse.ts
+++ b/src/stateMachine/mutation/SUQL/parse.ts
@@ -1,0 +1,68 @@
+/* eslint-disable no-param-reassign */
+import type { BQLMutationBlock, BormConfig } from '../../../types';
+import { clone } from 'radash';
+
+export type TqlRes = any;
+
+export const parseSUQLMutation = async (tqlRes: TqlRes, reqThings: any[], reqEdges: any[], config: BormConfig) => {
+	// todo: check if something weird happened
+	const expected = [...reqThings, ...reqEdges];
+
+	const parsed = expected
+		.map((exp) => {
+			//! reads all the insertions and gets the first match. This means each id must be unique
+			// @ts-expect-error - TODO description
+			const currentNode = tqlRes.insertions?.find((y) => y.get(`${exp.$bzId}`))?.get(`${exp.$bzId}`);
+			// console.log('current:', JSON.stringify(x));
+
+			if (exp.$op === 'create' || exp.$op === 'update' || exp.$op === 'link') {
+				/// Creation and links should show an $error. Update on the other hand might not get here as typeDB does not return deleted thibgs.
+				if (!(exp.$op === 'update') && !currentNode && exp.$id) {
+					return { $id: exp.$id, $error: "Does not exist or it's not linked to the parent" }; //todo: Return with $error not found?
+				}
+
+				const dbIdd = currentNode?.asThing().iid;
+				if (config.mutation?.noMetadata) {
+					const filteredObject = Object.entries(exp)
+						.filter(([k, _]) => !k.startsWith('$')) // Skip keys starting with '$'
+						.reduce(
+							(acc, [k, v]) => {
+								///Relations come with the $bzId in the roles instead of the $ids, lets replace them:
+								if (exp.$thingType === 'relation') {
+									const matchedThings = expected.filter((x) => x.$id && x.$bzId === v);
+									if (matchedThings.length > 1) {
+										throw new Error(`Multiple things with the same bzId ${v}`);
+									} else if (matchedThings.length === 1) {
+										acc[k] = matchedThings[0].$id;
+										return acc;
+									}
+									acc[k] = v;
+									return acc;
+								}
+								acc[k] = v;
+								return acc;
+							},
+							{} as Record<string, any>,
+						);
+					return filteredObject as BQLMutationBlock;
+				}
+				/// We revert the cleaning of the tempId
+				const tempId = exp.$tempId && !exp.$tempId.startsWith('_:') ? { $tempId: `_:${exp.$tempId}` } : {};
+				return { $dbId: dbIdd, ...exp, ...{ [exp.path]: exp.$id, ...tempId } } as BQLMutationBlock;
+			}
+			if (exp.$op === 'delete' || exp.$op === 'unlink') {
+				// todo when typeDB confirms deletions, check them here
+				return exp as BQLMutationBlock;
+			}
+			if (exp.$op === 'match') {
+				return undefined;
+			}
+			throw new Error(`Unsupported op ${exp.$op}`);
+
+			// console.log('config', config);
+		})
+		.filter((z) => z);
+
+	//console.log('ParseTQLResultNew', result);
+	return clone(parsed);
+};

--- a/src/stateMachine/mutation/SUQL/run.ts
+++ b/src/stateMachine/mutation/SUQL/run.ts
@@ -1,0 +1,60 @@
+import { TransactionType } from 'typedb-driver';
+import { getSessionOrOpenNewOne } from '../../../pipeline/transaction/helpers';
+import type { BormConfig, DBHandles } from '../../../types';
+
+export type TqlMutation = {
+	deletions: string;
+	deletionMatches: string;
+	insertions: string;
+	insertionMatches: string;
+};
+
+export const runSUQLMutation = async (tqlMutation: TqlMutation, dbHandles: DBHandles, config: BormConfig) => {
+	if (!tqlMutation) {
+		throw new Error('TQL request not built');
+	}
+	if (!((tqlMutation.deletions && tqlMutation.deletionMatches) || tqlMutation.insertions)) {
+		throw new Error('TQL request error, no things');
+	}
+
+	const { session } = await getSessionOrOpenNewOne(dbHandles, config);
+
+	const mutateTransaction = await session.transaction(TransactionType.WRITE);
+
+	if (!mutateTransaction) {
+		throw new Error("Can't create transaction");
+	}
+	//console.log('tqlMutation!', JSON.stringify(tqlMutation, null, 2));
+
+	// deletes and pre-update deletes
+	const tqlDeletion =
+		tqlMutation.deletionMatches &&
+		tqlMutation.deletions &&
+		`match ${tqlMutation.deletionMatches} delete ${tqlMutation.deletions}`;
+
+	// insertions and updates
+	const tqlInsertion =
+		tqlMutation.insertions &&
+		`${tqlMutation.insertionMatches ? `match ${tqlMutation.insertionMatches}` : ''} insert ${tqlMutation.insertions}`;
+
+	// does not receive a result
+	if (tqlDeletion) {
+		// console.log('DELETING: ', tqlDeletion);
+		await mutateTransaction.query.delete(tqlDeletion);
+		// console.log('X: ', x);
+	}
+
+	const insertionsStream = tqlInsertion && mutateTransaction.query.insert(tqlInsertion);
+
+	try {
+		const insertionsRes = insertionsStream ? await insertionsStream.collect() : undefined;
+		// console.log('INSERTION: ', insertionsRes);
+
+		await mutateTransaction.commit();
+		await mutateTransaction.close();
+		return { insertions: insertionsRes };
+	} catch (e: any) {
+		await mutateTransaction.close();
+		throw new Error(`Transaction failed: ${e.message}`);
+	}
+};

--- a/src/stateMachine/mutation/machine.ts
+++ b/src/stateMachine/mutation/machine.ts
@@ -9,10 +9,13 @@ import type {
 import { enrichBQLMutation } from './BQL/enrich';
 import type { TqlMutation } from './TQL/run';
 import { runTQLMutation } from './TQL/run';
+import { runSUQLMutation } from './SUQL/run';
 import type { TqlRes } from './TQL/parse';
+import { parseSUQLMutation } from './SUQL/parse';
 import { parseTQLMutation } from './TQL/parse';
 import { parseBQLMutation } from './BQL/parse';
 import { buildTQLMutation } from './TQL/build';
+import { buildSUQLMutation } from './SUQL/build';
 import { mutationPreQuery } from './BQL/preQuery';
 
 import { createMachine, invoke, transition, reduce, guard, interpret, state } from './robot3-wrapper';

--- a/tests/surrealdb/unit/mutations/mutationInit.test.ts
+++ b/tests/surrealdb/unit/mutations/mutationInit.test.ts
@@ -1,0 +1,1488 @@
+import 'jest';
+import { nanoid } from 'nanoid';
+
+import { cleanup, init } from '../../helpers/lifecycle';
+import { deepSort, expectArraysInObjectToContainSameElements } from '../../../helpers/matchers';
+import type { typesSchema } from '../../../mocks/generatedSchema';
+import type { TypeGen } from '../../../../src/types/typeGen';
+import type { WithBormMetadata } from '../../../../src/index';
+import type { UserType } from '../../types/testTypes';
+import type BormClient from '../../../../src/index';
+
+// some random issues forced a let here
+let firstUser = {
+	$entity: 'User',
+	name: 'John',
+	email: 'wrong email',
+	id: undefined,
+};
+
+const secondUser = {
+	$entity: 'User',
+	name: 'Jane',
+	email: 'jane@test.com',
+	id: undefined,
+};
+
+const thirdUser = {
+	$entity: 'User',
+	name: 'Jill',
+	email: 'jill@test.com',
+	id: undefined,
+};
+
+const godUser = {
+	$entity: 'God',
+	id: 'squarepusher',
+	name: 'Tom Jenkinson',
+	email: 'tom@warp.com',
+	power: 'rhythm',
+	isEvil: false,
+};
+
+const spaceOne = {
+	id: undefined,
+	name: 'Space 1',
+};
+
+const spaceTwo = {
+	id: undefined,
+	name: 'Space 2',
+};
+
+const spaceThree = {
+	id: 'newSpaceThreeId',
+	name: 'Space 3',
+};
+
+const spaceFour = {
+	id: 'newSpaceFourId',
+	name: 'Space 4',
+};
+
+describe('Mutations: Init', () => {
+	let dbName: string;
+	let bormClient: BormClient;
+
+	beforeAll(async () => {
+		const { dbName: configDbName, bormClient: configBormClient } = await init();
+
+		if (!configBormClient) {
+			throw new Error('Failed to initialize BormClient');
+		}
+		dbName = configDbName;
+
+		bormClient = configBormClient;
+	}, 25000);
+
+	it('b1[create] Basic', async () => {
+		expect(bormClient).toBeDefined();
+
+		const res = await bormClient.mutate(firstUser, { noMetadata: true });
+		const expectedUnit = {
+			id: '$unitId',
+			name: 'John',
+			email: 'wrong email',
+		};
+
+		expect(res).toBeInstanceOf(Array);
+		const [user] = res;
+		// @ts-expect-error - TODO description
+		expectArraysInObjectToContainSameElements(user, expectedUnit);
+		firstUser = { ...firstUser, id: user.id };
+	});
+
+	// it('b2a[update] Basic', async () => {
+	// 	expect(bormClient).toBeDefined();
+	// 	const res = await bormClient.mutate(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: firstUser.id,
+	// 			name: 'Johns not',
+	// 			email: 'john@test.com',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(res[0]).toEqual({
+	// 		name: 'Johns not',
+	// 		email: 'john@test.com',
+	// 	});
+
+	// 	if (!firstUser.id) {
+	// 		throw new Error('firstUser.id is undefined');
+	// 	}
+
+	// 	const res2 = await bormClient.query({
+	// 		$entity: 'User',
+	// 		$id: firstUser.id,
+	// 	});
+	// 	expect(res2).toEqual({
+	// 		id: firstUser.id,
+	// 		name: 'Johns not',
+	// 		email: 'john@test.com',
+	// 		$thing: 'User',
+	// 		$thingType: 'entity',
+	// 		$id: firstUser.id,
+	// 	});
+	// });
+
+	// it('b2b[update] Set null in single-attribute mutation should delete the attribute', async () => {
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$op: 'create',
+	// 			$entity: 'User',
+	// 			id: 'b2b-user',
+	// 			name: 'Foo',
+	// 			email: 'foo@test.com',
+	// 		},
+	// 		{ noMetadata: false },
+	// 	);
+
+	// 	const res = await bormClient.mutate(
+	// 		{
+	// 			$op: 'update',
+	// 			$entity: 'User',
+	// 			$id: 'b2b-user',
+	// 			name: null,
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(res[0]).toEqual({
+	// 		name: null,
+	// 	});
+
+	// 	const res2 = await bormClient.query(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: 'b2b-user',
+	// 			$fields: ['name', 'email'],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	expect(res2).toEqual({ email: 'foo@test.com' });
+
+	// 	/// CLEAN: delete b2b-user
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$op: 'delete',
+	// 			$entity: 'User',
+	// 			$id: 'b2b-user',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// });
+
+	// it('b2c[update] Set null in multi-attributes mutation should delete the attribute', async () => {
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$op: 'create',
+	// 			$entity: 'User',
+	// 			id: 'b2c-user',
+	// 			name: 'Foo',
+	// 			email: 'foo@test.com',
+	// 		},
+	// 		{ noMetadata: false },
+	// 	);
+
+	// 	const res = await bormClient.mutate(
+	// 		{
+	// 			$op: 'update',
+	// 			$entity: 'User',
+	// 			$id: 'b2c-user',
+	// 			name: null,
+	// 			email: 'bar@test.com',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(res[0]).toEqual({
+	// 		name: null,
+	// 		email: 'bar@test.com',
+	// 	});
+
+	// 	const res2 = await bormClient.query(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: 'b2c-user',
+	// 			$fields: ['name', 'email'],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	expect(res2).toEqual({ email: 'bar@test.com' });
+
+	// 	// CLEAN: delete b2c-user
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$op: 'delete',
+	// 			$entity: 'User',
+	// 			$id: 'b2c-user',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// });
+
+	// it('b2d[update] Set an empty string should update the attribute to an empty string', async () => {
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$op: 'create',
+	// 			$entity: 'User',
+	// 			id: 'b2d-user',
+	// 			name: 'Foo',
+	// 			email: 'foo@test.com',
+	// 		},
+	// 		{ noMetadata: false },
+	// 	);
+
+	// 	const res = await bormClient.mutate(
+	// 		{
+	// 			$op: 'update',
+	// 			$entity: 'User',
+	// 			$id: 'b2d-user',
+	// 			email: '',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(res[0]).toEqual({
+	// 		email: '',
+	// 	});
+
+	// 	const res2 = await bormClient.query(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: 'b2d-user',
+	// 			$fields: ['name', 'email'],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	expect(res2).toEqual({ name: 'Foo', email: '' });
+
+	// 	// CLEAN: delete b2d-user
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$op: 'delete',
+	// 			$entity: 'User',
+	// 			$id: 'b2d-user',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// });
+
+	// it('b3e[delete, entity] Basic', async () => {
+	// 	expect(bormClient).toBeDefined();
+	// 	const res = await bormClient.mutate({
+	// 		$entity: 'User',
+	// 		$op: 'delete',
+	// 		$id: firstUser.id,
+	// 	});
+
+	// 	expect(res).toEqual([
+	// 		{
+	// 			$thing: 'User',
+	// 			$thingType: 'entity',
+	// 			$op: 'delete',
+	// 			$id: firstUser.id,
+	// 			$bzId: expect.any(String),
+	// 		},
+	// 	]);
+
+	// 	if (!firstUser.id) {
+	// 		throw new Error('firstUser.id is undefined');
+	// 	}
+
+	// 	const res2 = await bormClient.query({
+	// 		$entity: 'User',
+	// 		$id: firstUser.id as string,
+	// 	});
+
+	// 	expect(res2).toBeNull();
+	// });
+
+	// it('b3r[delete, relation] Basic', async () => {
+	// 	expect(bormClient).toBeDefined();
+	// 	await bormClient.mutate({
+	// 		$relation: 'User-Accounts',
+	// 		id: 'r1',
+	// 		user: { id: 'u1' },
+	// 		accounts: [{ id: 'a1' }],
+	// 	});
+	// 	await bormClient.mutate({
+	// 		$relation: 'User-Accounts',
+	// 		$op: 'delete',
+	// 		$id: 'r1',
+	// 	});
+
+	// 	const res2 = await bormClient.query({
+	// 		$relation: 'User-Accounts',
+	// 		$id: 'r1',
+	// 	});
+
+	// 	expect(res2).toBeNull();
+
+	// 	/// clean user and account
+	// 	await bormClient.mutate([
+	// 		{
+	// 			$entity: 'User',
+	// 			$op: 'delete',
+	// 			$id: 'u1',
+	// 		},
+	// 		{
+	// 			$entity: 'Account',
+	// 			$op: 'delete',
+	// 			$id: 'a1',
+	// 		},
+	// 	]);
+	// });
+	// it('b3rn[delete, relation, nested] Basic', async () => {
+	// 	expect(bormClient).toBeDefined();
+	// 	//create nested object
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$relation: 'User-Accounts',
+	// 			id: 'r1',
+	// 			user: {
+	// 				'id': 'u2',
+	// 				'email': 'hey',
+	// 				'user-tags': [
+	// 					{ id: 'ustag1', color: { id: 'pink' } },
+	// 					{ id: 'ustag2', color: { id: 'gold' } },
+	// 					{ id: 'ustag3', color: { id: 'silver' } },
+	// 				],
+	// 			},
+	// 		},
+	// 		{ preQuery: true },
+	// 	);
+	// 	const res1 = await bormClient.query(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: 'u2',
+	// 			$fields: [{ $path: 'user-tags', $fields: ['id', 'color'] }],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	expect(deepSort(res1, 'id')).toEqual({
+	// 		'user-tags': [
+	// 			{ id: 'ustag1', color: 'pink' },
+	// 			{ id: 'ustag2', color: 'gold' },
+	// 			{ id: 'ustag3', color: 'silver' },
+	// 		],
+	// 	});
+
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$relation: 'User-Accounts',
+	// 			$id: 'r1',
+	// 			user: {
+	// 				'$op': 'update',
+	// 				'user-tags': [
+	// 					{ $id: 'ustag1', color: { $op: 'delete' } },
+	// 					{ $id: 'ustag2', color: { $op: 'delete' } },
+	// 				],
+	// 			},
+	// 		},
+	// 		{ preQuery: false },
+	// 	);
+
+	// 	const res2 = await bormClient.query(
+	// 		{
+	// 			$relation: 'User-Accounts',
+	// 			$id: 'r1',
+	// 			$fields: [
+	// 				'id',
+	// 				{
+	// 					$path: 'user',
+	// 					$fields: ['email', { $path: 'user-tags', $fields: ['id', 'color'] }],
+	// 				},
+	// 			],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	expect(deepSort(res2, 'id')).toEqual({
+	// 		id: 'r1',
+	// 		user: {
+	// 			'email': 'hey',
+	// 			'user-tags': [{ id: 'ustag1' }, { id: 'ustag2' }, { id: 'ustag3', color: 'silver' }],
+	// 		},
+	// 	});
+
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$relation: 'User-Accounts',
+	// 			$id: 'r1',
+	// 			user: {
+	// 				'$op': 'update',
+	// 				'user-tags': [
+	// 					{ $id: 'ustag3', $op: 'delete', color: { $op: 'delete' } },
+	// 					{ $id: 'ustag2', $op: 'delete' },
+	// 				],
+	// 			},
+	// 		},
+	// 		{ preQuery: false },
+	// 	);
+
+	// 	const res3 = await bormClient.query(
+	// 		{
+	// 			$relation: 'User-Accounts',
+	// 			$id: 'r1',
+	// 			$fields: [
+	// 				'id',
+	// 				{
+	// 					$path: 'user',
+	// 					$fields: ['email', { $path: 'user-tags', $fields: ['id', 'color'] }],
+	// 				},
+	// 			],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(res3).toEqual({
+	// 		id: 'r1',
+	// 		user: {
+	// 			'email': 'hey',
+	// 			'user-tags': [{ id: 'ustag1' }],
+	// 		},
+	// 	});
+	// 	/// clean user
+	// 	await bormClient.mutate([
+	// 		{
+	// 			$entity: 'User',
+	// 			$op: 'delete',
+	// 			$id: 'u2',
+	// 		},
+	// 	]);
+	// });
+
+	// it('b4[create, children] Create with children', async () => {
+	// 	expect(bormClient).toBeDefined();
+	// 	const res = await bormClient.mutate(
+	// 		{
+	// 			...secondUser,
+	// 			spaces: [{ name: spaceOne.name }, { name: spaceTwo.name }],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	//console.log('res', res);
+
+	// 	// @ts-expect-error - TODO description
+	// 	spaceOne.id = res?.find((r) => r.name === 'Space 1').id;
+	// 	// @ts-expect-error - TODO description
+	// 	spaceTwo.id = res?.find((r) => r.name === 'Space 2').id;
+	// 	// @ts-expect-error - TODO description
+	// 	secondUser.id = res?.find((r) => r.name === 'Jane').id;
+
+	// 	expect(res).toBeDefined();
+	// 	expect(res).toBeInstanceOf(Object);
+
+	// 	expect(JSON.parse(JSON.stringify(res))).toEqual([
+	// 		{
+	// 			email: 'jane@test.com',
+	// 			id: secondUser.id,
+	// 			name: 'Jane',
+	// 		},
+	// 		spaceOne,
+	// 		spaceTwo,
+	// 		{
+	// 			spaces: spaceOne.id,
+	// 			users: secondUser.id,
+	// 		},
+	// 		{
+	// 			spaces: spaceTwo.id,
+	// 			users: secondUser.id,
+	// 		},
+	// 	]);
+
+	// 	if (!secondUser.id) {
+	// 		throw new Error('firstUser.id is undefined');
+	// 	}
+
+	// 	const res2 = await bormClient.query(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: secondUser.id,
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	expect(deepSort(res2)).toEqual({
+	// 		id: secondUser.id,
+	// 		name: 'Jane',
+	// 		email: 'jane@test.com',
+	// 		spaces: [spaceOne.id, spaceTwo.id].sort(),
+	// 	});
+
+	// 	// clean spaceOne
+	// 	await bormClient.mutate([
+	// 		{
+	// 			$entity: 'Space',
+	// 			$op: 'delete',
+	// 			$id: spaceOne.id,
+	// 		},
+	// 	]);
+	// });
+
+	// it('b4.2[create, link] Create all then link', async () => {
+	// 	expect(bormClient).toBeDefined();
+
+	// 	/// create third user
+	// 	const res1 = await bormClient.mutate(
+	// 		{
+	// 			...thirdUser,
+	// 		},
+	// 		{ noMetadata: true, preQuery: true },
+	// 	);
+
+	// 	// create spaces
+	// 	const res2 = await bormClient.mutate(
+	// 		[
+	// 			{
+	// 				$entity: 'Space',
+	// 				...spaceThree,
+	// 			},
+	// 			{
+	// 				$entity: 'Space',
+	// 				...spaceFour,
+	// 			},
+	// 		],
+	// 		{ noMetadata: true, preQuery: true },
+	// 	);
+
+	// 	// console.log('res', res);
+
+	// 	// @ts-expect-error - TODO description
+	// 	spaceThree.id = res2?.find((r) => r.name === 'Space 3').id;
+	// 	// @ts-expect-error - TODO description
+	// 	spaceFour.id = res2?.find((r) => r.name === 'Space 4').id;
+	// 	thirdUser.id = res1[0].id;
+
+	// 	expect(res1).toBeDefined();
+	// 	expect(res1).toBeInstanceOf(Object);
+	// 	expect(res2).toBeDefined();
+	// 	expect(res2).toBeInstanceOf(Object);
+
+	// 	// link the user to the spaces
+	// 	//console.log('res3-3', spaceThree.id, spaceFour.id, thirdUser.id);
+	// 	const res3 = await bormClient.mutate(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: thirdUser.id,
+	// 			spaces: [
+	// 				{ $id: spaceThree.id, $op: 'link' },
+	// 				{ $id: spaceFour.id, $op: 'link' },
+	// 			],
+	// 		},
+
+	// 		{ noMetadata: true, preQuery: true },
+	// 	);
+
+	// 	expectArraysInObjectToContainSameElements(JSON.parse(JSON.stringify(res3)), [
+	// 		{
+	// 			spaces: spaceThree.id,
+	// 			users: thirdUser.id,
+	// 		},
+	// 		{
+	// 			spaces: spaceFour.id,
+	// 			users: thirdUser.id,
+	// 		},
+	// 	]);
+	// });
+
+	// it('TODO:b4.3[update, link] Link ALL (without ids)', async () => {
+	// 	expect(bormClient).toBeDefined();
+
+	// 	const res = await bormClient.mutate(
+	// 		{
+	// 			$entity: 'Space',
+	// 			$id: 'space-3',
+	// 			users: [{ $op: 'link' }],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(JSON.parse(JSON.stringify(res))).toEqual([
+	// 		{
+	// 			email: 'jane@test.com',
+	// 			id: secondUser.id,
+	// 			name: 'Jane',
+	// 		},
+	// 		spaceOne,
+	// 		spaceTwo,
+	// 		{
+	// 			spaces: spaceOne.id,
+	// 			users: secondUser.id,
+	// 		},
+	// 		{
+	// 			spaces: spaceTwo.id,
+	// 			users: secondUser.id,
+	// 		},
+	// 	]);
+	// });
+
+	// it('TODO:b4.4[create, link] Create and link ALL (without ids)', async () => {
+	// 	expect(bormClient).toBeDefined();
+
+	// 	const res = await bormClient.mutate(
+	// 		{
+	// 			$entity: 'Space',
+	// 			id: 'space-5', //no $op and no $id means create
+	// 			users: [{ $op: 'link' }],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(JSON.parse(JSON.stringify(res))).toEqual([
+	// 		{
+	// 			email: 'jane@test.com',
+	// 			id: secondUser.id,
+	// 			name: 'Jane',
+	// 		},
+	// 		spaceOne,
+	// 		spaceTwo,
+	// 		{
+	// 			spaces: spaceOne.id,
+	// 			users: secondUser.id,
+	// 		},
+	// 		{
+	// 			spaces: spaceTwo.id,
+	// 			users: secondUser.id,
+	// 		},
+	// 	]);
+
+	// 	//clean
+	// 	await bormClient.mutate({
+	// 		$entity: 'Space',
+	// 		$op: 'delete',
+	// 		$id: 'space-5',
+	// 	});
+	// });
+
+	// it('b5[update, children] Update children', async () => {
+	// 	expect(bormClient).toBeDefined();
+	// 	const res = await bormClient.mutate(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: secondUser.id,
+	// 			spaces: [
+	// 				// todo: { $filter: { name: 'Space 1' }, name: 'newSpace1' },
+	// 				{ $id: spaceTwo.id, name: 'newSpace2' },
+	// 			],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(JSON.parse(JSON.stringify(res[0]))).toEqual(
+	// 		// { id: expect.any(String), name: 'newSpace1' },
+	// 		{ name: 'newSpace2' },
+	// 	);
+
+	// 	if (!secondUser.id) {
+	// 		throw new Error('firstUser.id is undefined');
+	// 	}
+
+	// 	const res2 = await bormClient.query(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: secondUser.id,
+	// 			$fields: [{ $path: 'spaces', $id: spaceTwo.id, $fields: ['name'] }],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	expect(res2).toEqual({
+	// 		spaces: { name: 'newSpace2' }, // todo there is a $id so at some point this should not be an array
+	// 	});
+
+	// 	// clean spaceTwo
+	// 	await bormClient.mutate([
+	// 		{
+	// 			$entity: 'Space',
+	// 			$op: 'delete',
+	// 			$id: spaceTwo.id,
+	// 		},
+	// 	]);
+	// });
+
+	// it('b6.1[create, withId] Create with id (override default)', async () => {
+	// 	expect(bormClient).toBeDefined();
+	// 	const res = await bormClient.mutate(
+	// 		[
+	// 			{
+	// 				$entity: 'Color',
+	// 				id: 'red',
+	// 			},
+	// 			{
+	// 				$entity: 'Color',
+	// 				id: 'green',
+	// 			},
+	// 		],
+	// 		{ noMetadata: true },
+	// 	);
+	// 	expect(JSON.parse(JSON.stringify(res))).toEqual([
+	// 		{
+	// 			id: 'red',
+	// 		},
+	// 		{ id: 'green' },
+	// 	]);
+
+	// 	/// CLEAN: delete the newly created colors
+	// 	await bormClient.mutate([
+	// 		{
+	// 			$entity: 'Color',
+	// 			$op: 'delete',
+	// 			$id: 'red',
+	// 		},
+	// 		{
+	// 			$entity: 'Color',
+	// 			$op: 'delete',
+	// 			$id: 'green',
+	// 		},
+	// 	]);
+	// });
+
+	// it('b6.2[create, default id] Create without id', async () => {
+	// 	await bormClient.mutate([
+	// 		{
+	// 			$entity: 'Space',
+	// 			$id: 'space-3',
+	// 			kinds: [{ name: 'b6-k' }],
+	// 		},
+	// 	]);
+
+	// 	const res = await bormClient.query(
+	// 		{
+	// 			$relation: 'Kind',
+	// 			$filter: { name: 'b6-k' },
+	// 			$fields: ['id', 'name'],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(res).toEqual([
+	// 		{
+	// 			name: 'b6-k',
+	// 			id: expect.any(String),
+	// 		},
+	// 	]);
+	// 	//@ts-expect-error - TODO
+	// 	const kindId = res[0].id;
+
+	// 	/// CLEAN
+	// 	await bormClient.mutate({
+	// 		$relation: 'Kind',
+	// 		$id: kindId,
+	// 		$op: 'delete',
+	// 	});
+	// });
+
+	// it('b7[create, inherited] inheritedAttributesMutation', async () => {
+	// 	expect(bormClient).toBeDefined();
+	// 	const res = await bormClient.mutate(godUser, { noMetadata: true });
+	// 	expect(res[0]).toEqual({
+	// 		id: 'squarepusher',
+	// 		name: 'Tom Jenkinson',
+	// 		email: 'tom@warp.com',
+	// 		power: 'rhythm',
+	// 		isEvil: false,
+	// 	});
+	// });
+
+	// it('b8[create, multiple, date] Next-auth example ', async () => {
+	// 	expect(bormClient).toBeDefined();
+
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$entity: 'Session',
+	// 			user: 'user1',
+	// 			sessionToken: '8ac4c6d7-e8ba-4e63-9e30-1d662b626ad4',
+	// 			expires: new Date('2023-06-10T14:58:09.066Z'),
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	const sessions = await bormClient.query(
+	// 		{
+	// 			$entity: 'Session',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(sessions).toEqual([
+	// 		{
+	// 			expires: '2023-06-10T14:58:09.066Z',
+	// 			id: expect.any(String),
+	// 			sessionToken: '8ac4c6d7-e8ba-4e63-9e30-1d662b626ad4',
+	// 			user: 'user1',
+	// 		},
+	// 	]);
+	// });
+
+	// it('n1[create, nested] nested', async () => {
+	// 	expect(bormClient).toBeDefined();
+
+	// 	const mutated = await bormClient.mutate(
+	// 		{
+	// 			$relation: 'Kind',
+	// 			name: 'myTest',
+	// 			space: 'space-3',
+	// 			dataFields: [{ $op: 'create', name: 'myTestField', space: 'space-3' }],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	const fieldId = mutated?.find((m) => m.name === 'myTestField')?.id;
+	// 	const kindId = mutated?.find((m) => m.name === 'myTest')?.id;
+
+	// 	const kinds = await bormClient.query(
+	// 		{
+	// 			$relation: 'Kind',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	const expectedKindTemplate = [
+	// 		{
+	// 			id: kindId, // '$newKindId',
+	// 			name: 'myTest',
+	// 			space: 'space-3',
+	// 			fields: [fieldId], // todo: replace by template ids
+	// 			dataFields: [fieldId],
+	// 		},
+	// 		{ id: 'kind-book', name: 'book', space: 'space-2' },
+	// 	];
+	// 	// @ts-expect-error - TODO description
+	// 	expectArraysInObjectToContainSameElements(kinds, expectedKindTemplate);
+
+	// 	const fields = await bormClient.query(
+	// 		{
+	// 			$relation: 'DataField',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	const expectedFieldsTemplate = [
+	// 		{
+	// 			id: fieldId,
+	// 			name: 'myTestField',
+	// 			kinds: [kindId],
+	// 			space: 'space-3',
+	// 		},
+	// 	];
+
+	// 	// @ts-expect-error - TODO description
+	// 	expectArraysInObjectToContainSameElements(fields, expectedFieldsTemplate);
+	// 	// const { $newKindId, $newFieldId } = ids2;
+
+	// 	/// also the ids must match
+	// 	// expectResLikeTemplate(ids, ids2);
+
+	// 	/// delete both things
+	// 	await bormClient.mutate(
+	// 		[
+	// 			{
+	// 				$relation: 'Kind',
+	// 				$op: 'delete',
+	// 				$id: kindId,
+	// 			},
+	// 			{
+	// 				$relation: 'DataField',
+	// 				$op: 'delete',
+	// 				$id: fieldId,
+	// 			},
+	// 		],
+	// 		{ noMetadata: true },
+	// 	);
+	// });
+
+	// it('n2[create, nested] nested, self referenced', async () => {
+	// 	expect(bormClient).toBeDefined();
+
+	// 	const mutated = await bormClient.mutate(
+	// 		{
+	// 			$relation: 'Kind',
+	// 			name: 'myTestKind1',
+	// 			space: 'space-3',
+	// 			dataFields: [
+	// 				{
+	// 					$op: 'create',
+	// 					name: 'myTestField',
+	// 					space: 'space-3',
+	// 					kinds: [
+	// 						{
+	// 							$op: 'create',
+	// 							name: 'myTestKind2',
+	// 							space: 'space-3',
+	// 						},
+	// 					],
+	// 				},
+	// 			],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	const myTestKind1Id = mutated?.find((m) => m.name === 'myTestKind1')?.id;
+	// 	const myTestFieldId = mutated?.find((m) => m.name === 'myTestField')?.id;
+	// 	const myTestKind2Id = mutated?.find((m) => m.name === 'myTestKind2')?.id;
+
+	// 	const kinds = await bormClient.query(
+	// 		{
+	// 			$relation: 'Kind',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	const expectedKindTemplate = [
+	// 		{ id: 'kind-book', name: 'book', space: 'space-2' },
+	// 		{
+	// 			id: myTestKind1Id,
+	// 			name: 'myTestKind1',
+	// 			space: 'space-3',
+	// 			fields: [myTestFieldId],
+	// 			dataFields: [myTestFieldId],
+	// 		},
+	// 		{
+	// 			id: myTestKind2Id,
+	// 			name: 'myTestKind2',
+	// 			space: 'space-3',
+	// 			fields: [myTestFieldId],
+	// 			dataFields: [myTestFieldId],
+	// 		},
+	// 	];
+
+	// 	// const ids = expectResLikeTemplate(kinds, expectedKindTemplate);
+	// 	// @ts-expect-error - TODO description
+	// 	expectArraysInObjectToContainSameElements(kinds, expectedKindTemplate); // todo: delete when matcher is ready
+
+	// 	const fields = await bormClient.query(
+	// 		{
+	// 			$relation: 'DataField',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	const expectedFieldsTemplate = [
+	// 		{
+	// 			id: myTestFieldId,
+	// 			name: 'myTestField',
+	// 			kinds: [myTestKind1Id, myTestKind2Id],
+	// 			space: 'space-3',
+	// 		},
+	// 	];
+
+	// 	// const ids2 = expectResLikeTemplate(fields, expectedFieldsTemplate);
+	// 	// @ts-expect-error - TODO description
+	// 	expectArraysInObjectToContainSameElements(fields, expectedFieldsTemplate); // todo: delete when matcher is ready
+	// 	// const { $newFieldId } = ids2;
+
+	// 	/// also the ids must match
+	// 	// expectResLikeTemplate(ids, ids2);
+
+	// 	/// delete both things
+	// 	await bormClient.mutate(
+	// 		[
+	// 			{
+	// 				$relation: 'DataField',
+	// 				$op: 'delete',
+	// 				$id: myTestFieldId,
+	// 			},
+	// 			{
+	// 				$relation: 'Kind',
+	// 				$op: 'delete',
+	// 				$id: myTestKind1Id,
+	// 			},
+	// 			{
+	// 				$relation: 'Kind',
+	// 				$op: 'delete',
+	// 				$id: myTestKind2Id,
+	// 			},
+	// 		],
+	// 		{ noMetadata: true },
+	// 	);
+	// });
+
+	// it('n3[delete, nested] nested delete', async () => {
+	// 	expect(bormClient).toBeDefined();
+
+	// 	const mutated = await bormClient.mutate(
+	// 		{
+	// 			$relation: 'Kind',
+	// 			name: 'myTestKind1',
+	// 			space: 'space-3',
+	// 			dataFields: [
+	// 				{
+	// 					$op: 'create',
+	// 					name: 'myTestField',
+	// 					space: 'space-3',
+	// 					kinds: [
+	// 						{
+	// 							$op: 'create',
+	// 							name: 'myTestKind2',
+	// 							space: 'space-3',
+	// 						},
+	// 					],
+	// 				},
+	// 			],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	const myTestKind1Id = mutated?.find((m) => m.name === 'myTestKind1')?.id;
+	// 	// console.log('myTestKind1Id', myTestKind1Id);
+
+	// 	/// delete both things
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$relation: 'Kind',
+	// 			$op: 'delete',
+	// 			$id: myTestKind1Id,
+	// 			dataFields: [{ $op: 'delete', kinds: [{ $op: 'delete' }] }],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	/*
+  //   #target query:
+  //   match
+  //   $root isa Kind, has id "6a830f80-59f1-469e-93cb-99a772c96406";
+  //   $f (kinds: $a, kinds: $other) isa Field;
+  //   $other isa Kind;
+
+  //   delete
+  //   $root isa Kind;
+  //   $nested-f isa Field;
+  //   $nested-other isa Kind;
+
+  //   #target ibql:
+    
+
+  //   const nodes = [
+  //     { $id: 'rootId', $relation: 'Kind', $op: 'delete' },
+  //     { $id: '$f', $relation: 'Field', $op: 'delete' },
+  //     { $if: '$other', $relation: 'Kind', $op: 'delete' },
+  //   ];
+  //   const edges = [{ $relation: 'Field', $id: 'localNestedFieldId', kinds: ['$rootId', 'localNestedKindsId'] }];
+  //   */
+	// 	const kinds = await bormClient.query(
+	// 		{
+	// 			$relation: 'Kind',
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	// we expect both kinds to be deleted and show only the data.tql one
+	// 	expect(kinds).toEqual([
+	// 		{
+	// 			id: 'kind-book',
+	// 			name: 'book',
+	// 			space: 'space-2',
+	// 		},
+	// 	]);
+	// });
+
+	// it('TEMP:buffer', async () => {
+	// 	// Some failed tests generate a fail in the next test, this test is here to prevent that to happen in ui
+	// 	// todo: fix the borm / jest issue instead
+	// 	await bormClient.query({ $entity: 'Space' });
+	// });
+
+	// it('u1[update, multiple] Shared ids', async () => {
+	// 	expect(bormClient).toBeDefined();
+
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$entity: 'Space',
+	// 			id: 'sp1',
+	// 			users: [
+	// 				{
+	// 					id: 'u1',
+	// 					name: 'new name',
+	// 				},
+	// 				{
+	// 					id: 'u2',
+	// 					name: 'new name 2',
+	// 				},
+	// 			],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$entity: 'Space',
+	// 			$id: 'sp1',
+	// 			users: [
+	// 				{
+	// 					$op: 'update',
+	// 					name: 'updated',
+	// 				},
+	// 			],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	const res = await bormClient.query(
+	// 		{
+	// 			$entity: 'Space',
+	// 			$id: 'sp1',
+	// 			$fields: [
+	// 				{
+	// 					$path: 'users',
+	// 					$fields: ['name'],
+	// 				},
+	// 			],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(res).toEqual({
+	// 		users: [
+	// 			{
+	// 				name: 'updated',
+	// 			},
+	// 			{
+	// 				name: 'updated',
+	// 			},
+	// 		],
+	// 	});
+
+	// 	const allUsers = await bormClient.query(
+	// 		{
+	// 			$entity: 'User',
+	// 			$fields: ['name'],
+	// 		},
+	// 		{ noMetadata: true, returnNulls: true },
+	// 	);
+
+	// 	expect(deepSort(allUsers, 'name')).toEqual([
+	// 		{
+	// 			name: 'Ann',
+	// 		},
+	// 		{
+	// 			name: 'Antoine',
+	// 		},
+	// 		{
+	// 			name: 'Beatrix Kiddo',
+	// 		},
+	// 		{
+	// 			name: 'Ben',
+	// 		},
+	// 		{
+	// 			name: 'Charlize',
+	// 		},
+	// 		{
+	// 			name: 'Jane', /// sing from previous test (b4)
+	// 		},
+	// 		{
+	// 			name: 'Jill', /// coming from previous test
+	// 		},
+	// 		{
+	// 			name: 'Loic',
+	// 		},
+	// 		{
+	// 			name: 'Richard David James',
+	// 		},
+	// 		{
+	// 			name: 'Tom Jenkinson',
+	// 		},
+	// 		{
+	// 			name: 'updated',
+	// 		},
+	// 		{
+	// 			name: 'updated',
+	// 		},
+	// 	]);
+
+	// 	/// delete created users and spaces
+	// 	await bormClient.mutate(
+	// 		[
+	// 			{
+	// 				$entity: 'User',
+	// 				$id: ['u1', 'u2'],
+	// 				$op: 'delete',
+	// 			},
+	// 			{
+	// 				$entity: 'Space',
+	// 				$id: 'sp1',
+	// 				$op: 'delete',
+	// 			},
+	// 		],
+
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	/// get all users again
+	// 	const allUsers2 = await bormClient.query(
+	// 		{
+	// 			$entity: 'User',
+	// 			$fields: ['name'],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	/// expect only original users
+	// 	expect(deepSort(allUsers2, 'name')).toEqual([
+	// 		{
+	// 			name: 'Ann',
+	// 		},
+	// 		{
+	// 			name: 'Antoine',
+	// 		},
+	// 		{
+	// 			name: 'Beatrix Kiddo',
+	// 		},
+	// 		{
+	// 			name: 'Ben',
+	// 		},
+	// 		{
+	// 			name: 'Charlize',
+	// 		},
+	// 		{
+	// 			name: 'Jane', /// coming from previous test
+	// 		},
+	// 		{
+	// 			name: 'Jill', /// coming from previous test
+	// 		},
+	// 		{
+	// 			name: 'Loic',
+	// 		},
+	// 		{
+	// 			name: 'Richard David James',
+	// 		},
+	// 		{
+	// 			name: 'Tom Jenkinson',
+	// 		},
+	// 	]);
+	// });
+
+	// it('u2[update, multiple, nested(many), noId] Update only children (no id)', async () => {
+	// 	// This test might fail if b4 fails
+
+	// 	expect(bormClient).toBeDefined();
+
+	// 	/// cardinality MANY
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: 'user1',
+	// 			spaces: [{ $op: 'update', name: 'space2ORspace1' }],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	const allSpaces = await bormClient.query(
+	// 		{
+	// 			$entity: 'Space',
+	// 			$fields: ['id', 'name'],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(deepSort(allSpaces, 'id')).toEqual([
+	// 		{
+	// 			id: 'newSpaceFourId',
+	// 			name: 'Space 4',
+	// 		},
+	// 		{
+	// 			id: 'newSpaceThreeId',
+	// 			name: 'Space 3',
+	// 		},
+	// 		{
+	// 			id: 'space-1',
+	// 			name: 'space2ORspace1',
+	// 		},
+	// 		{
+	// 			id: 'space-2',
+	// 			name: 'space2ORspace1',
+	// 		},
+	// 		{
+	// 			id: 'space-3',
+	// 			name: 'Not-owned',
+	// 		},
+	// 	]);
+
+	// 	/// get back original space names
+	// 	await bormClient.mutate([
+	// 		{
+	// 			$id: 'space-2',
+	// 			$entity: 'Space',
+	// 			name: 'Dev',
+	// 		},
+	// 		{
+	// 			$id: 'space-3',
+	// 			$entity: 'Space',
+	// 			name: 'Not-owned',
+	// 		},
+	// 		{
+	// 			$id: 'space-1',
+	// 			$entity: 'Space',
+	// 			name: 'Production',
+	// 		},
+	// 	]);
+	// });
+
+	// it('u3[update, multiple, nested(many), noId] Update only but all children (no id)', async () => {
+	// 	/// This test might fail if b4 fails
+	// 	expect(bormClient).toBeDefined();
+	// 	const currentSpacesOfUser2And5 = await bormClient.query(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: ['user2', 'user5'],
+	// 			$fields: ['id', { $path: 'spaces', $fields: ['id', 'name'] }],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+	// 	expect(deepSort(currentSpacesOfUser2And5, 'id')).toEqual([
+	// 		{
+	// 			id: 'user2',
+	// 			spaces: [
+	// 				{
+	// 					id: 'space-2',
+	// 					name: 'Dev',
+	// 				},
+	// 			],
+	// 		},
+	// 		{
+	// 			id: 'user5',
+	// 			spaces: [
+	// 				{
+	// 					id: 'space-1',
+	// 					name: 'Production',
+	// 				},
+	// 			],
+	// 		},
+	// 	]);
+
+	// 	/// cardinality MANY
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: ['user2', 'user5'],
+	// 			spaces: [{ $op: 'update', name: 'space2ORspace1Bis' }],
+	// 		},
+	// 		{ noMetadata: true, preQuery: true },
+	// 	);
+
+	// 	const allSpaces = await bormClient.query(
+	// 		{
+	// 			$entity: 'Space',
+	// 			$fields: ['id', 'name'],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(deepSort(allSpaces, 'id')).toEqual([
+	// 		{
+	// 			id: 'newSpaceFourId',
+	// 			name: 'Space 4',
+	// 		},
+	// 		{
+	// 			id: 'newSpaceThreeId',
+	// 			name: 'Space 3',
+	// 		},
+	// 		{
+	// 			id: 'space-1',
+	// 			name: 'space2ORspace1Bis',
+	// 		},
+	// 		{
+	// 			id: 'space-2',
+	// 			name: 'space2ORspace1Bis',
+	// 		},
+	// 		{
+	// 			id: 'space-3',
+	// 			name: 'Not-owned',
+	// 		},
+	// 	]);
+
+	// 	/// get back original space names
+	// 	await bormClient.mutate([
+	// 		{
+	// 			$id: 'space-1',
+	// 			$entity: 'Space',
+	// 			name: 'Production',
+	// 		},
+	// 		{
+	// 			$id: 'space-2',
+	// 			$entity: 'Space',
+	// 			name: 'Dev',
+	// 		},
+	// 	]);
+	// });
+
+	// it('u4[update, multiple, nested(one), noId] Update all children (no id)', async () => {
+	// 	expect(bormClient).toBeDefined();
+
+	// 	/// cardinality ONE
+	// 	await bormClient.mutate(
+	// 		{
+	// 			$entity: 'Account',
+	// 			$id: 'account3-1',
+	// 			user: {
+	// 				$op: 'update',
+	// 				email: 'theNewEmailOfAnn@test.com',
+	// 			},
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	const allOriginalUsers = await bormClient.query(
+	// 		{
+	// 			$entity: 'User',
+	// 			$id: ['user1', 'user2', 'user3', 'user4', 'user5'],
+	// 			$fields: ['id', 'email'],
+	// 		},
+	// 		{ noMetadata: true },
+	// 	);
+
+	// 	expect(deepSort(allOriginalUsers, 'id')).toEqual([
+	// 		{
+	// 			email: 'antoine@test.com',
+	// 			id: 'user1',
+	// 		},
+	// 		{
+	// 			email: 'loic@test.com',
+	// 			id: 'user2',
+	// 		},
+	// 		{
+	// 			email: 'theNewEmailOfAnn@test.com',
+	// 			id: 'user3',
+	// 		},
+	// 		{
+	// 			id: 'user4',
+	// 		},
+	// 		{
+	// 			email: 'charlize@test.com',
+	// 			id: 'user5',
+	// 		},
+	// 	]);
+
+	// 	/// get back original emails
+	// 	await bormClient.mutate([
+	// 		{
+	// 			$id: 'user3',
+	// 			$entity: 'User',
+	// 			email: 'ann@test.com',
+	// 		},
+	// 	]);
+	// });
+
+	/*
+  it('f1[json] Basic nested json-like field', async () => {
+    /// In general, this json-like is used only as a way to group properties that actually belong to the entity
+    /// So Address is maybe not the best example, it should probably be a node itself.
+    expect(bormClient).toBeDefined();
+    const res = await bormClient.mutate([
+      {
+        $entity: 'User',
+        $id: 'user3',
+        address: {
+          $embeddedObject: true,
+          city: 'Moscow',
+          street: 'Lenina',
+          house: 1,
+        },
+      },
+    ]);
+    expect(res?.length).toBe(17);
+  });
+*/
+
+	afterAll(async () => {
+		await cleanup(bormClient, dbName);
+	});
+});


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 73474a3f556d7117b06a1ee700c534ca6071bee6  | 
|--------|--------|

### Summary:
Introduced SurrealDB mutation handling with new functions for building, parsing, and running SUQL mutations, and added corresponding unit tests.

**Key points**:
- Added `src/stateMachine/mutation/SUQL/build.ts` to build SUQL mutations.
- Added `src/stateMachine/mutation/SUQL/parse.ts` to parse SUQL mutations.
- Added `src/stateMachine/mutation/SUQL/run.ts` to run SUQL mutations.
- Updated `src/stateMachine/mutation/machine.ts` to integrate SUQL mutation functions.
- Added unit tests in `tests/surrealdb/unit/mutations/mutationInit.test.ts` for SUQL mutation functionalities.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->