### PR TITLE
fix: prune empty filters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 📝 following beta format X.Y.Z where Y = breaking change and Z = feature and fix. Later => FAIL.FEATURE.FIX
 
+
+## 0.11.11(2024-11-07)
+
+- Fix: Issue with empty filters.
+
 ## 0.11.10(2024-11-06)
 
 - Fix: Issue with surrealdb wrapper. Now catches errors too before trying to reconnect.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blitznocode/blitz-orm",
-	"version": "0.11.10",
+	"version": "0.11.11",
 	"author": "blitznocode.com",
 	"description": "Blitz-orm is an Object Relational Mapper (ORM) for graph databases that uses a JSON query language called Blitz Query Language (BQL). BQL is similar to GraphQL but uses JSON instead of strings. This makes it easier to build dynamic queries.",
 	"main": "dist/index.mjs",

--- a/src/stateMachine/mutation/bql/enrich.ts
+++ b/src/stateMachine/mutation/bql/enrich.ts
@@ -35,6 +35,12 @@ const cleanStep = (node: BQLMutationBlock, field: string) => {
 			throw new Error('[Internal] TempId already modified');
 		}
 	}
+
+	if (field === '$filter') {
+		if (node.$filter && Object.keys(node.$filter).length === 0) {
+			node.$filter = undefined;
+		}
+	}
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/stateMachine/query/bql/enrich.ts
+++ b/src/stateMachine/query/bql/enrich.ts
@@ -81,8 +81,12 @@ export const enrichBQLQuery = (rawBqlQuery: RawBQLQuery[], schema: EnrichedBormS
 					value[QueryPath as any] = meta.nodePath;
 					const currentSchema = getCurrentSchema(schema, node);
 					if (value.$filter) {
-						value.$filter = enrichFilter(value.$filter, value.$thing, schema);
-						value.$filterByUnique = checkFilterByUnique(value.$filter, currentSchema);
+						if (Object.keys(value.$filter).length === 0) {
+							value.$filter = undefined;
+						} else {
+							value.$filter = enrichFilter(value.$filter, value.$thing, schema);
+							value.$filterByUnique = checkFilterByUnique(value.$filter, currentSchema);
+						}
 					}
 					// if no fields, then it's all fields
 					if (value.$fields) {

--- a/src/stateMachine/query/surql/buildRefs.ts
+++ b/src/stateMachine/query/surql/buildRefs.ts
@@ -109,9 +109,10 @@ const createEdgeFields = (
 			);
 			const FIELDS = [...META, ...DATA_FIELDS, ...LINK_FIELDS].join(',\n');
 			const FROM = `FROM $parent.\`${ef[FieldSchema].path}\`[*]`;
-			const WHERE = ef.$filter
-				? `WHERE id AND(${buildSuqlFilter(parseFilter(ef.$filter, ef.$thing, schema))})`
-				: 'WHERE id';
+			const WHERE =
+				ef.$filter && Object.keys(ef.$filter).length > 0
+					? `WHERE id AND(${buildSuqlFilter(parseFilter(ef.$filter, ef.$thing, schema))})`
+					: 'WHERE id';
 			const SORT = ef.$sort ? buildSorter(ef.$sort) : '';
 			const LIMIT = typeof ef.$limit === 'number' ? `LIMIT ${ef.$limit}` : '';
 			const OFFSET = typeof ef.$offset === 'number' ? `START ${ef.$offset}` : '';


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes issue with empty filters by pruning them in `enrich.ts` and `buildRefs.ts`.
> 
>   - **Behavior**:
>     - Prune empty `$filter` objects by setting them to `undefined` in `cleanStep()` in `mutation/bql/enrich.ts` and `enrichBQLQuery()` in `query/bql/enrich.ts`.
>     - Modify `createEdgeFields()` in `query/surql/buildRefs.ts` to handle empty `$filter` by setting it to `undefined`.
>   - **Versioning**:
>     - Update version in `package.json` to `0.11.11`.
>     - Add changelog entry for version `0.11.11` in `changelog.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Blitzapps%2Fblitz-orm&utm_source=github&utm_medium=referral)<sup> for a9f69b8bd37c20ffa23200032d66af157220ea98. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->