### PR TITLE
Ignore percentage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 📝 following beta format X.Y.Z where Y = breaking change and Z = feature and fix. Later => FAIL.FEATURE.FIX
 
+## 0.11.12-23(2024-11-12)
+
+- Fix: Actions are now run one after each other properly.
 
 ## 0.11.12-23(2024-11-11)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blitznocode/blitz-orm",
-	"version": "0.11.23",
+	"version": "0.11.24",
 	"author": "blitznocode.com",
 	"description": "Blitz-orm is an Object Relational Mapper (ORM) for graph databases that uses a JSON query language called Blitz Query Language (BQL). BQL is similar to GraphQL but uses JSON instead of strings. This makes it easier to build dynamic queries.",
 	"main": "dist/index.mjs",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -495,7 +495,7 @@ export const enrichSchema = (schema: BormSchema, dbHandles: DBHandles): Enriched
 		}),
 	) as EnrichedBormSchema;
 
-	console.log('schema and enrichedSchema', JSON.stringify(schema), JSON.stringify(enrichedSchema));
+	//console.log('schema and enrichedSchema', JSON.stringify(schema), JSON.stringify(enrichedSchema));
 	return enrichedSchema;
 };
 

--- a/src/stateMachine/mutation/bql/enrich.ts
+++ b/src/stateMachine/mutation/bql/enrich.ts
@@ -60,8 +60,14 @@ export const enrichBQLMutation = (
 			if (!parent || !key) {
 				return;
 			}
+
 			if (isObject(value)) {
 				const paths = meta.nodePath?.split('.') || [];
+				if (paths.some((p) => p.startsWith('%'))) {
+					//we don't go inside %vars even if they are objects
+					return;
+				}
+
 				if ('$root' in value) {
 					// This is hte $root object, we will split the real root if needed in this iteration
 				} else if (!('$thing' in value || '$entity' in value || '$relation' in value)) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> BQL mutations now ignore `%`-prefixed variables and pre-hook transformations update nodes directly, with version updated to 0.11.24.
> 
>   - **Behavior**:
>     - In `enrich.ts`, BQL mutations now ignore variables prefixed with `%` during traversal.
>     - In `preHookTransformations.ts`, refactored to update `subNode` directly with `workingNode` after transformations.
>   - **Versioning**:
>     - Updated version in `package.json` from `0.11.23` to `0.11.24`.
>   - **Misc**:
>     - Commented out a `console.log` in `helpers.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Blitzapps%2Fblitz-orm&utm_source=github&utm_medium=referral)<sup> for cac7bc8238f33aeee436ecb738304fc9f5241d19. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->