### PR TITLE
Fix: Filtering by a single id was not considered as unique

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 📝 following beta format X.Y.Z where Y = breaking change and Z = feature and fix. Later => FAIL.FEATURE.FIX
 
+## 0.12.7(2025-02-17)
+
+- Fix: Query filtered by single id
+
 ## 0.12.6(2025-02-13)
 
 - Fix: Fixed an issue that was creating multiple clients and adding noise in mutations and queries

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blitznocode/blitz-orm",
-	"version": "0.12.6",
+	"version": "0.12.7",
 	"author": "blitznocode.com",
 	"description": "Blitz-orm is an Object Relational Mapper (ORM) for graph databases that uses a JSON query language called Blitz Query Language (BQL). BQL is similar to GraphQL but uses JSON instead of strings. This makes it easier to build dynamic queries.",
 	"main": "dist/index.mjs",

--- a/src/stateMachine/query/bql/enrich.ts
+++ b/src/stateMachine/query/bql/enrich.ts
@@ -61,7 +61,11 @@ export const enrichBQLQuery = (rawBqlQuery: RawBQLQuery[], schema: EnrichedBormS
 					if (!Array.isArray(value.$id)) {
 						value.$filterByUnique = true;
 					}
-					if (currentSchema?.idFields?.length !== 1) {
+					if (currentSchema.idFields.length === 1) {
+						const [idField] = currentSchema.idFields;
+						value.$filter = { ...value.$filter, [idField]: value.$id };
+						delete value.$id;
+					} else {
 						throw new Error('Multiple ids not yet enabled / composite ids');
 					}
 				} else if ('$entity' in value || '$relation' in value || '$thing' in value) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes handling of single ID filters in `enrichBQLQuery()` to consider them unique, updating version to 0.12.7.
> 
>   - **Behavior**:
>     - Fixes handling of single ID filters in `enrichBQLQuery()` in `enrich.ts`. Now considers single ID as unique and moves `$id` to `$filter` when `idFields` length is 1.
>   - **Versioning**:
>     - Updates version to `0.12.7` in `package.json`.
>     - Adds changelog entry for version `0.12.7` in `changelog.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Blitzapps%2Fblitz-orm&utm_source=github&utm_medium=referral)<sup> for 04c063a4a53ad506717efb9596fdef52342291b0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->