### PR TITLE
Throw on non-WebSocket SurrealDB URLs

### DIFF
--- a/src/adapters/surrealdb/client.ts
+++ b/src/adapters/surrealdb/client.ts
@@ -40,6 +40,16 @@ const DEFAULT_RECONNECT: ReconnectConfig = {
   retryDelayJitter: 0,
 };
 
+function assertWebSocketProtocol(url: string): void {
+  const protocol = url.split('://', 1)[0]?.toLowerCase();
+  if (protocol !== 'ws' && protocol !== 'wss') {
+    throw new Error(
+      `SurrealDB connection requires a WebSocket URL (ws:// or wss://), got "${url}". ` +
+        `Multi-query transactions are not supported over HTTP.`,
+    );
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Client
 // ─────────────────────────────────────────────────────────────────────────────
@@ -58,6 +68,7 @@ export class SurrealClient {
   #latestError = '';
 
   constructor(config: ConnectionConfig, options: SurrealClientOptions = {}) {
+    assertWebSocketProtocol(config.url);
     this.#config = config;
     this.#reconnect = { ...DEFAULT_RECONNECT, ...options.reconnect };
     this.#versionCheck = options.versionCheck ?? false;

--- a/src/adapters/surrealdb/client.ts
+++ b/src/adapters/surrealdb/client.ts
@@ -40,7 +40,7 @@ const DEFAULT_RECONNECT: ReconnectConfig = {
   retryDelayJitter: 0,
 };
 
-function assertWebSocketProtocol(url: string): void {
+const assertWebSocketProtocol = (url: string): void => {
   const protocol = url.split('://', 1)[0]?.toLowerCase();
   if (protocol !== 'ws' && protocol !== 'wss') {
     throw new Error(
@@ -48,7 +48,7 @@ function assertWebSocketProtocol(url: string): void {
         `Multi-query transactions are not supported over HTTP.`,
     );
   }
-}
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Client


### PR DESCRIPTION
## Summary

- Validate the SurrealDB connection URL in the `SurrealClient` constructor and throw a descriptive error if the protocol is not `ws://` or `wss://`.
- The codebase relies on multi-query transactions (`BEGIN`/`COMMIT` via `client.beginTransaction()`), which SurrealDB does not support over HTTP — so failing fast with a clear message is better than a confusing runtime error deep in a mutation.

## Test plan

- [ ] Configure a `dbConnector` with an `http://` URL and confirm construction throws with the new message.
- [ ] Configure a `dbConnector` with a `ws://` URL and confirm the client connects as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate SurrealDB connection URLs in the `SurrealClient` constructor and throw a clear error if the protocol isn’t `ws://` or `wss://`. This fails fast on HTTP configs and avoids confusing runtime errors with multi‑query transactions.

<sup>Written for commit fd1a89852f71ab31df4f84cf4125d2eff4a36022. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

