### PR TITLE
Fix: Some filter operators were not implemented

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 📝 following beta format X.Y.Z where Y = breaking change and Z = feature and fix. Later => FAIL.FEATURE.FIX
 
+## 0.17.5(2026-04-25)
+
+- Fix: Implement missing SurrealDB filter operators in query generation
+- Fix: Adjust query optimization/buildLogical handling for filter operator paths
+- Tests: Add coverage for missing filter operator scenarios in query tests
+
 ## 0.17.4(2026-04-09)
 
 - Fix: Build — ensure published `dist` matches the tagged release sources

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blitznocode/blitz-orm",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "author": "blitznocode.com",
   "description": "Blitz-orm is an Object Relational Mapper (ORM) for graph databases that uses a JSON query language called Blitz Query Language (BQL). BQL is similar to GraphQL but uses JSON instead of strings. This makes it easier to build dynamic queries.",
   "main": "dist/index.mjs",

--- a/src/adapters/surrealdb/filters/filters.ts
+++ b/src/adapters/surrealdb/filters/filters.ts
@@ -123,6 +123,21 @@ export const parseFilter = (filter: Filter, currentThing: string, schema: Enrich
   return wasArray ? resultArray : resultArray[0];
 };
 
+const serializeLiteral = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return 'NONE';
+  }
+  if (typeof value === 'string') {
+    // JSON.stringify produces a double-quoted string with proper escaping,
+    // which SurrealDB accepts as a string literal.
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  throw new Error(`Cannot serialize filter value of type ${typeof value}: ${JSON.stringify(value)}`);
+};
+
 export const buildSuqlFilter = (filter: object): string => {
   if (filter === null || filter === undefined) {
     return '';
@@ -185,14 +200,12 @@ export const buildSuqlFilter = (filter: object): string => {
             // Handle other operators
             const surrealOperator = operator.replace('$', '');
             if (Array.isArray(nextValue)) {
-              parts.push(
-                `${key} ${surrealOperator} [${nextValue.map((v) => (v === null ? 'NONE' : `'${v}'`)).join(', ')}]`,
-              );
+              parts.push(`${key} ${surrealOperator} [${nextValue.map(serializeLiteral).join(', ')}]`);
             } else if (isObject(nextValue)) {
               const nestedFilter = buildSuqlFilter(nextValue);
               parts.push(`${key} ${surrealOperator} ${nestedFilter}`);
             } else {
-              parts.push(`${key} ${surrealOperator} ${nextValue === null ? 'NONE' : `'${nextValue}'`}`);
+              parts.push(`${key} ${surrealOperator} ${serializeLiteral(nextValue)}`);
             }
           }
         } else {
@@ -203,10 +216,10 @@ export const buildSuqlFilter = (filter: object): string => {
       // Handle simple field equality
       if (Array.isArray(value)) {
         const operator = key.startsWith('$') ? key.replace('$', '') : 'IN'; //maybe  could do const operator = 'IN';
-        parts.push(`${key} ${operator} [${value.map((v) => (v === null ? 'NONE' : `'${v}'`)).join(', ')}]`);
+        parts.push(`${key} ${operator} [${value.map(serializeLiteral).join(', ')}]`);
       } else {
         const operator = key.startsWith('$') ? key.replace('$', '') : '='; //maybe  could do const operator = '=';
-        parts.push(`${key} ${operator} ${value === null ? 'NONE' : `'${value}'`}`);
+        parts.push(`${key} ${operator} ${serializeLiteral(value)}`);
       }
     }
   }

--- a/src/adapters/surrealdb/filters/filters.ts
+++ b/src/adapters/surrealdb/filters/filters.ts
@@ -5,13 +5,27 @@ import { SuqlMetadata } from '../../../types/symbols';
 
 const surqlOperators = {
   $eq: '$=',
+  $neq: '$!=',
+  $gt: '$>',
+  $lt: '$<',
+  $gte: '$>=',
+  $lte: '$<=',
+  $contains: '$CONTAINS',
+  $containsNot: '$CONTAINSNOT',
   $not: '$!',
   $or: '$OR',
   $and: '$AND',
   $in: '$IN',
+  $nin: '$NOT IN',
+  $containsAll: '$CONTAINSALL',
+  $containsAny: '$CONTAINSANY',
+  $containsNone: '$CONTAINSNONE',
   $id: 'record::id(id)',
   $exists: '$exists',
 };
+
+const SCALAR_VALUE_OPERATORS = ['$eq', '$neq', '$gt', '$lt', '$gte', '$lte', '$contains', '$containsNot'] as const;
+const LIST_VALUE_OPERATORS = ['$in', '$nin', '$containsAll', '$containsAny', '$containsNone'] as const;
 
 export const parseFilter = (filter: Filter, currentThing: string, schema: EnrichedBormSchema): Filter | Filter[] => {
   if (filter === null || filter === undefined) {
@@ -52,11 +66,11 @@ export const parseFilter = (filter: Filter, currentThing: string, schema: Enrich
         }
 
         //VALUE OPERATORS
-        if (key === '$eq') {
-          return { ...acc, $eq: undefined, [surqlOperators[key]]: value };
+        if ((SCALAR_VALUE_OPERATORS as readonly string[]).includes(key)) {
+          return { ...acc, [key]: undefined, [surqlOperators[key as keyof typeof surqlOperators]]: value };
         }
-        if (key === '$in') {
-          return { ...acc, $in: undefined, [surqlOperators[key]]: value };
+        if ((LIST_VALUE_OPERATORS as readonly string[]).includes(key)) {
+          return { ...acc, [key]: undefined, [surqlOperators[key as keyof typeof surqlOperators]]: value };
         }
 
         throw new Error(`Unknown filter operator ${key}`);

--- a/src/adapters/surrealdb/query/buildLogical.ts
+++ b/src/adapters/surrealdb/query/buildLogical.ts
@@ -309,7 +309,7 @@ const buildDataFieldFilter = (
         });
         continue;
       }
-      if ((op === '$eq' || op === '$ne') && right === null) {
+      if ((op === '$eq' || op === '$neq') && right === null) {
         filters.push({
           type: 'null',
           op: op === '$eq' ? 'IS' : 'IS NOT',
@@ -507,7 +507,7 @@ const buildLinkFieldFilter = (
 
   const {
     $eq: _eq,
-    $ne: _ne,
+    $neq: _neq,
     $contains: _contains,
     $containsNot: _containsNot,
     $in: _in,
@@ -526,7 +526,7 @@ const buildLinkFieldFilter = (
 
   const filters: Filter[] = [];
 
-  for (const op of ['$exists', '$eq', '$ne', '$contains', '$containsNot']) {
+  for (const op of ['$exists', '$eq', '$neq', '$contains', '$containsNot']) {
     const value = nestedFilter.data[op];
     if (value === undefined) {
       continue;
@@ -540,7 +540,7 @@ const buildLinkFieldFilter = (
       });
       continue;
     }
-    if ((op === '$eq' || op === '$ne') && value === null) {
+    if ((op === '$eq' || op === '$neq') && value === null) {
       filters.push({
         type: 'null',
         op: op === '$eq' ? 'IS' : 'IS NOT',
@@ -653,7 +653,7 @@ const buildSort = (sort?: ({ field: string; desc?: boolean } | string)[]): Sort[
 
 const scalarOpMap: Record<string, ScalarFilter['op']> = {
   $eq: '=',
-  $ne: '!=',
+  $neq: '!=',
   $gt: '>',
   $lt: '<',
   $gte: '>=',

--- a/src/adapters/surrealdb/query/optimize.ts
+++ b/src/adapters/surrealdb/query/optimize.ts
@@ -77,15 +77,21 @@ export const optimizeSource = (params: {
   // computed_biref takes precedence because it converts to a sub-query that traverses a normal ref,
   // which is faster than traversing a computed ref directly.
   // The same logic applies to nested filters.
+  // Only filters with ops that preserve relationship-traversal semantics are eligible;
+  // otherwise an unsupported op on a higher-priority filter would block lower-priority eligible ones.
 
   const biRefFilter =
     findFilter(
       filters,
-      (f): f is ComputedBiRefFilter => f.type === 'computed_biref' && f.oppositeCardinality === 'ONE',
+      (f): f is ComputedBiRefFilter =>
+        f.type === 'computed_biref' && f.oppositeCardinality === 'ONE' && isRefTraversalOp(f.op),
     ) ??
-    findFilter(filters, (f): f is ComputedBiRefFilter => f.type === 'computed_biref') ??
-    findFilter(filters, (f): f is BiRefFilter => f.type === 'biref' && f.oppositeCardinality === 'ONE') ??
-    findFilter(filters, (f): f is BiRefFilter => f.type === 'biref');
+    findFilter(filters, (f): f is ComputedBiRefFilter => f.type === 'computed_biref' && isRefTraversalOp(f.op)) ??
+    findFilter(
+      filters,
+      (f): f is BiRefFilter => f.type === 'biref' && f.oppositeCardinality === 'ONE' && isRefTraversalOp(f.op),
+    ) ??
+    findFilter(filters, (f): f is BiRefFilter => f.type === 'biref' && isRefTraversalOp(f.op));
   if (biRefFilter) {
     const subQuery = convertRefFilterToRelationshipTraversal(biRefFilter, schema, thing);
     if (subQuery) {
@@ -148,18 +154,21 @@ const convertIdFilterToRecordPointer = (
 };
 
 /**
- * Return sub query if the filter can be converted to a relationship traversal.
- *
- * Only `IN` and `CONTAINSANY` preserve semantics when rewritten as
+ * Only `IN` and `CONTAINSANY` preserve semantics when a (computed) biref filter is rewritten as
  * "fetch the linked records and return their parents". Operators like
  * `NOT IN`, `CONTAINSALL`, and `CONTAINSNONE` need the full filter form.
+ */
+const isRefTraversalOp = (op: BiRefFilter['op']): boolean => op === 'IN' || op === 'CONTAINSANY';
+
+/**
+ * Return sub query if the filter can be converted to a relationship traversal.
  */
 const convertRefFilterToRelationshipTraversal = (
   filter: BiRefFilter | ComputedBiRefFilter,
   schema: DRAFT_EnrichedBormSchema,
   thing: DRAFT_EnrichedBormEntity | DRAFT_EnrichedBormRelation,
 ): SubQuery | undefined => {
-  if (filter.op !== 'IN' && filter.op !== 'CONTAINSANY') {
+  if (!isRefTraversalOp(filter.op)) {
     return undefined;
   }
   const field = thing.fields[filter.left];

--- a/src/adapters/surrealdb/query/optimize.ts
+++ b/src/adapters/surrealdb/query/optimize.ts
@@ -149,12 +149,19 @@ const convertIdFilterToRecordPointer = (
 
 /**
  * Return sub query if the filter can be converted to a relationship traversal.
+ *
+ * Only `IN` and `CONTAINSANY` preserve semantics when rewritten as
+ * "fetch the linked records and return their parents". Operators like
+ * `NOT IN`, `CONTAINSALL`, and `CONTAINSNONE` need the full filter form.
  */
 const convertRefFilterToRelationshipTraversal = (
   filter: BiRefFilter | ComputedBiRefFilter,
   schema: DRAFT_EnrichedBormSchema,
   thing: DRAFT_EnrichedBormEntity | DRAFT_EnrichedBormRelation,
 ): SubQuery | undefined => {
+  if (filter.op !== 'IN' && filter.op !== 'CONTAINSANY') {
+    return undefined;
+  }
   const field = thing.fields[filter.left];
   if (!field) {
     throw new Error(`Field ${filter.left} not found in ${thing.name}`);

--- a/src/bql/query/enrich.ts
+++ b/src/bql/query/enrich.ts
@@ -487,7 +487,24 @@ export const enrichFilter = ($filter: Filter | Filter[], $thing: string, schema:
         } else if (['$not', '$or', '$and'].includes(key)) {
           // We don't want to enrich the special keys; we enrich nested things instead
           acc[key] = enrichFilter(value, $thing, schema);
-        } else if (['$eq', '$in', '$exists'].includes(key)) {
+        } else if (
+          [
+            '$exists',
+            '$eq',
+            '$neq',
+            '$gt',
+            '$lt',
+            '$gte',
+            '$lte',
+            '$contains',
+            '$containsNot',
+            '$in',
+            '$nin',
+            '$containsAll',
+            '$containsAny',
+            '$containsNone',
+          ].includes(key)
+        ) {
           acc[key] = value;
         } else {
           throw new Error(`[Internal] Unknown filter operator ${key}`);

--- a/tests/unit/queries/query.ts
+++ b/tests/unit/queries/query.ts
@@ -3061,4 +3061,186 @@ export const testQuery = createTest('Query', (ctx) => {
       ],
     });
   });
+
+  // FILTER OPERATORS
+  // One test per operator defined in BQLFilter / NestedBQLFilter.
+
+  it('op-eq[filter, $eq] - scalar equality', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { provider: { $eq: 'google' } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-1' }, { id: 'account2-1' }]);
+  });
+
+  it('op-neq[filter, $neq] - scalar inequality', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { provider: { $neq: 'google' } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-2' }, { id: 'account1-3' }, { id: 'account3-1' }]);
+  });
+
+  it('op-gt[filter, $gt] - greater than', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { provider: { $gt: 'facebook' } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-1' }, { id: 'account1-3' }, { id: 'account2-1' }]);
+  });
+
+  it('op-gte[filter, $gte] - greater than or equal', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { provider: { $gte: 'github' } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-1' }, { id: 'account1-3' }, { id: 'account2-1' }]);
+  });
+
+  it('op-lt[filter, $lt] - less than', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { provider: { $lt: 'github' } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-2' }, { id: 'account3-1' }]);
+  });
+
+  it('op-lte[filter, $lte] - less than or equal', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { provider: { $lte: 'facebook' } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-2' }, { id: 'account3-1' }]);
+  });
+
+  it('op-contains[filter, $contains] - string substring match', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { provider: { $contains: 'oogle' } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-1' }, { id: 'account2-1' }]);
+  });
+
+  it('op-containsNot[filter, $containsNot] - string substring negation', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { provider: { $containsNot: 'oogle' } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-2' }, { id: 'account1-3' }, { id: 'account3-1' }]);
+  });
+
+  it('op-in[filter, $in] - value in list', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { provider: { $in: ['github', 'facebook'] } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-2' }, { id: 'account1-3' }, { id: 'account3-1' }]);
+  });
+
+  it('op-nin[filter, $nin] - value not in list', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { provider: { $nin: ['github', 'facebook'] } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-1' }, { id: 'account2-1' }]);
+  });
+
+  it('op-containsAll[filter, $containsAll] - link field contains all ids', async () => {
+    const res = await ctx.query(
+      {
+        $entity: 'User',
+        $filter: { accounts: { $containsAll: ['account1-1', 'account1-2'] } },
+        $fields: ['id'],
+      },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'user1' }]);
+  });
+
+  it('op-containsAny[filter, $containsAny] - link field contains any id', async () => {
+    const res = await ctx.query(
+      {
+        $entity: 'User',
+        $filter: { accounts: { $containsAny: ['account1-1', 'account2-1'] } },
+        $fields: ['id'],
+      },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'user1' }, { id: 'user2' }]);
+  });
+
+  it('op-containsNone[filter, $containsNone] - link field contains none of ids', async () => {
+    const res = await ctx.query(
+      {
+        $entity: 'User',
+        $filter: { accounts: { $containsNone: ['account1-1', 'account1-2', 'account1-3'] } },
+        $fields: ['id'],
+      },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([
+      { id: 'god1' },
+      { id: 'superuser1' },
+      { id: 'user2' },
+      { id: 'user3' },
+      { id: 'user4' },
+      { id: 'user5' },
+    ]);
+  });
+
+  it('op-exists-true[filter, $exists] - field is set', async () => {
+    const res = await ctx.query(
+      { $entity: 'User', $filter: { email: { $exists: true } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([
+      { id: 'god1' },
+      { id: 'superuser1' },
+      { id: 'user1' },
+      { id: 'user2' },
+      { id: 'user3' },
+      { id: 'user5' },
+    ]);
+  });
+
+  it('op-exists-false[filter, $exists] - field is unset', async () => {
+    const res = await ctx.query(
+      { $entity: 'User', $filter: { email: { $exists: false } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'user4' }]);
+  });
+
+  it('op-not[filter, $not] - logical negation', async () => {
+    const res = await ctx.query(
+      { $entity: 'Account', $filter: { $not: { provider: 'google' } }, $fields: ['id'] },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-2' }, { id: 'account1-3' }, { id: 'account3-1' }]);
+  });
+
+  it('op-or[filter, $or] - logical disjunction via array of filters', async () => {
+    const res = await ctx.query(
+      {
+        $entity: 'Account',
+        // @ts-expect-error - TODO: This is valid syntax but requires refactoring the filters
+        $filter: [{ provider: 'google' }, { provider: 'github' }],
+        $fields: ['id'],
+      },
+      { noMetadata: true },
+    );
+    expect(deepSort(res, 'id')).toEqual([{ id: 'account1-1' }, { id: 'account1-3' }, { id: 'account2-1' }]);
+  });
+
+  it('op-and[filter, implicit $and] - multiple fields', async () => {
+    const res = await ctx.query(
+      {
+        $entity: 'User',
+        $filter: { name: 'Antoine', email: 'antoine@test.com' },
+        $fields: ['id'],
+      },
+      { noMetadata: true },
+    );
+    expect(res).toEqual({ id: 'user1' });
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add full support for missing filter operators and fix the `$ne` → `$neq` bug in the SurrealDB adapter. Also serialize filter literals by type to prevent cross-quoted values.

- **Bug Fixes**
  - Implemented scalar ops: `$neq`, `$gt`, `$lt`, `$gte`, `$lte`, `$contains`, `$containsNot`.
  - Implemented list ops: `$nin`, `$containsAll`, `$containsAny`, `$containsNone` (plus `$in`).
  - Fixed `$ne` → `$neq`; standardized literal serialization (strings, numbers, booleans) and null handling.
  - Enrichment whitelists all supported operators.
  - Optimizer rewrites only `IN` and `CONTAINSANY`, skipping ineligible birefs so unsupported ops don’t block rewrites.
  - Release `@blitznocode/blitz-orm` 0.17.5 with changelog update and unit tests covering each operator.

<sup>Written for commit a8df8cd5ed2cf8867c2d01f652754938018ca4d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

